### PR TITLE
Fix crash on settings loading

### DIFF
--- a/src/game/eventhandler.cpp
+++ b/src/game/eventhandler.cpp
@@ -285,8 +285,10 @@ bool EventHandler::mapKeyToAction(int player, InputHandler::Action action, int k
             {
                 iter = m_keyToActionMap.erase(iter);
             }
-
-            iter++;
+            else
+            {
+                iter++;
+            }
         }
 
         m_keyToActionMap[key] = {player, action};


### PR DESCRIPTION
erase() returns iterator following the removed element. It's no
need to increment it as it already points to the `next' element,
and when it points to end(), incrementing it leads to a crash.