### PR TITLE
Editor: use qSetGlobalQHashSeed with Qt 5.6+

### DIFF
--- a/src/editor/main.cpp
+++ b/src/editor/main.cpp
@@ -25,10 +25,17 @@
 #include <memory>
 #include <cstdlib>
 
+#if QT_VERSION < 0x50600
 extern Q_CORE_EXPORT QBasicAtomicInt qt_qhash_seed;
+#endif
+
 int main(int argc, char ** argv)
 {
+#if QT_VERSION >= 0x50600
+    qSetGlobalQHashSeed(0);
+#else
     qt_qhash_seed.store(0);
+#endif
 
     QApplication::setOrganizationName(Config::Common::QSETTINGS_COMPANY_NAME);
     QApplication::setApplicationName(Config::Editor::QSETTINGS_SOFTWARE_NAME);


### PR DESCRIPTION
`qt_qhash_seed` is no more exported in recent Qt 5.9.x versions, so use the public functions for it available since Qt 5.6.

Fixes commit 8b6ea072e46c2b689ba8b851c60e20864037893d.

Though, the better fix would be making sure to write the XML output in the same order every time -- perhaps by writing the entries of hashes by the sorted keys?