### PR TITLE
Translate metadata files into German

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 
 <a href="https://www.youtube.com/watch?feature=player_embedded&v=3hrIzzItggQ">Video of the game</a>
 
-Dust Racing (Dustrac) is a tile-based, cross-platform 2D racing game written
+Dust Racing 2D (Dustrac) is a tile-based, cross-platform 2D racing game written
 in Qt (C++) and OpenGL.
 
-Dust Racing comes with a Qt-based level editor for easy level creation.
+Dust Racing 2D comes with a Qt-based level editor for easy level creation.
 A separate engine, MiniCore, is used for physics modeling.
 
 ## Features
@@ -39,13 +39,13 @@ A separate engine, MiniCore, is used for physics modeling.
 
 ## License
 
-Dust Racing source code is licensed under GNU GPLv3.
+Dust Racing 2D source code is licensed under GNU GPLv3.
 See COPYING for the complete license text.
 
-Dust Racing includes the source code for the GLEW library.
+Dust Racing 2D includes the source code for the GLEW library.
 See src/game/MiniCore/Graphics/glew/glew.h for the license text.
 
-Dust Racing includes the source code for the GLM library.
+Dust Racing 2D includes the source code for the GLM library.
 See src/game/MiniCore/Graphics/glm/ogl-math/glm/glm.hpp for the license text.
 
 All image files, except where otherwise noted, are licensed under
@@ -89,7 +89,7 @@ By stopping on the pit your tires will be repaired.
 
 ### Custom track files
 
-Dust Racing searches for race tracks in `~/DustRacingTracks/` where you can place your own race tracks.
+Dust Racing 2D searches for race tracks in `~/DustRacingTracks/` where you can place your own race tracks.
 
 On Linux/Unix also `$XDG_DATA_HOME/DustRacing2D/tracks` is added to search paths, or `$HOME/.local/share/DustRacing2D/tracks` if `$XDG_DATA_HOME` is not defined.
 

--- a/src/dustrac-editor.desktop.in
+++ b/src/dustrac-editor.desktop.in
@@ -1,7 +1,9 @@
 [Desktop Entry]
 Name=Dust Racing 2D Level Editor
 GenericName=2D racing game level editor
+GenericName[de]=2D-Rennspiel-Level-Editor
 Comment=2D racing game level editor
+Comment[de]=2D-Rennspiel-Level-Editor
 Exec=dustrac-editor
 Icon=dustrac-editor
 Type=Application

--- a/src/dustrac-editor.desktop.opt.in
+++ b/src/dustrac-editor.desktop.opt.in
@@ -1,7 +1,9 @@
 [Desktop Entry]
 Name=Dust Racing 2D Level Editor
 GenericName=2D racing game level editor
+GenericName[de]=2D-Rennspiel-Level-Editor
 Comment=2D racing game level editor
+Comment[de]=2D-Rennspiel-Level-Editor
 Exec=/opt/dustrac/dustrac-editor
 Icon=dustrac-editor
 Type=Application

--- a/src/dustrac-game.desktop.in
+++ b/src/dustrac-game.desktop.in
@@ -1,7 +1,9 @@
 [Desktop Entry]
 Name=Dust Racing 2D
 GenericName=Top-down 2D racing game
+GenericName[de]=2D-Rennspiel in Vogelperspektive
 Comment=2D racing game
+Comment[de]=2D-Rennspiel
 Exec=dustrac-game
 Icon=dustrac-game
 Type=Application

--- a/src/dustrac-game.desktop.opt.in
+++ b/src/dustrac-game.desktop.opt.in
@@ -1,7 +1,9 @@
 [Desktop Entry]
 Name=Dust Racing 2D
 GenericName=Top-down 2D racing game
+GenericName[de]=2D-Rennspiel in Vogelperspektive
 Comment=2D racing game
+Comment[de]=2D-Rennspiel
 Exec=/opt/dustrac/dustrac-game
 Icon=dustrac-game
 Type=Application

--- a/src/dustrac.appdata.xml
+++ b/src/dustrac.appdata.xml
@@ -5,31 +5,55 @@
   <project_license>GPL-3.0 and CC BY-SA-3.0</project_license>
   <name>Dust Racing 2D</name>
   <summary>Traditional top-down car racing game including a level editor.</summary>
+  <summary xml:lang="de">Traditionelles Autorennspiel aus der Vogelperspektive, mit Leveleditor.</summary>
   <description>
     <p>
       Dust Racing 2D (Dustrac) is a tile-based, cross-platform 2D racing game written in Qt (C++) and OpenGL.
     </p>
+    <p xml:lang="de">
+      Dust Racing 2D (Dustrac) ist ein kachelbasiertes, plattformübergreifendes 2D-Rennspiel, das in Qt (C++) und OpenGL geschrieben wurde.
+    </p>
     <p>
+      Features
+    </p>
+    <p xml:lang="de">
       Features
     </p>
     <ul>
       <li>1-2 human players againts 11 challenging computer players</li>
+      <li xml:lang="de">1-2 menschliche Spieler gegen 11 herausfordernde Computerspieler</li>
       <li>3 difficulty settings: Easy, Medium, Hard</li>
+      <li xml:lang="de">3 Schwierigkeitsstufen: Einfach, mittel, schwierig</li>
       <li>Split-screen two player game (vertical or horizontal)</li>
+      <li xml:lang="de">Zweispielerspiel mit geteiltem Bildschirm (vertikal/horizontal)</li>
       <li>Game modes: Race, Time Trial, Duel</li>
+      <li xml:lang="de">Spielmodi: Rennen, Zeitrennen, Duell</li>
       <li>2D graphics with some 3D objects</li>
+      <li xml:lang="de">2D-Grafik mit einigen 3D-Objekten</li>
       <li>Smooth game play and physics</li>
+      <li xml:lang="de">Flüssiges Spielgeschehen und Physik</li>
       <li>Multiple race tracks</li>
+      <li xml:lang="de">Mehrere Rennstrecken</li>
       <li>Finishing in TOP-6 will unlock the next race track</li>
+      <li xml:lang="de">Rennen auf dem 6. oder einem besseren Platz beenden, um die nächste Rennstrecke freizuschalten</li>
       <li>Star ratings based on the best positions on each race track</li>
+      <li xml:lang="de">Sternenbewertung basierend auf der Bestposition auf jeder einzelnen Rennstrecke</li>
       <li>Easy to create new race tracks with the level editor</li>
+      <li xml:lang="de">Neue Rennstrecken können leicht mit dem Level-Editor erstellt werden</li>
       <li>Engine and collision sounds</li>
+      <li xml:lang="de">Motoren- und Kollisionsgeräusche</li>
       <li>Pit stops</li>
+      <li xml:lang="de">Boxenstopps</li>
       <li>Runs windowed or fullscreen</li>
+      <li xml:lang="de">Läuft im Fenster- oder Vollbildmodus</li>
       <li>Will be forever completely free</li>
+      <li xml:lang="de">Wird für immer völlig frei und kostenlos sein</li>
     </ul>
     <p>
       Dust Racing 2D comes with a Qt-based level editor for easy level creation. A separate engine, MiniCore, is used for physics modeling.
+    </p>
+    <p xml:lang="de">
+      Dust Racing 2D hat einen Qt-basierten Level-Editor für die einfache Levelerstellung. Eine separate Engine, MiniCore, wird für die Physikmodellierung benutzt.
     </p>
   </description>
   <screenshots>

--- a/src/dustrac.appdata.xml
+++ b/src/dustrac.appdata.xml
@@ -7,7 +7,7 @@
   <summary>Traditional top-down car racing game including a level editor.</summary>
   <description>
     <p>
-      Dust Racing (Dustrac) is a tile-based, cross-platform 2D racing game written in Qt (C++) and OpenGL.
+      Dust Racing 2D (Dustrac) is a tile-based, cross-platform 2D racing game written in Qt (C++) and OpenGL.
     </p>
     <p>
       Features
@@ -29,7 +29,7 @@
       <li>Will be forever completely free</li>
     </ul>
     <p>
-      Dust Racing comes with a Qt-based level editor for easy level creation. A separate engine, MiniCore, is used for physics modeling.
+      Dust Racing 2D comes with a Qt-based level editor for easy level creation. A separate engine, MiniCore, is used for physics modeling.
     </p>
   </description>
   <screenshots>


### PR DESCRIPTION
This PR does two things:

1. Change “Dust Racing” to “Dust Racing 2D” in README/metadata files (for consistency)
2. Translate the AppData and Desktop Entry files to German