### PR TITLE
appdata: a couple of fixes

### DIFF
--- a/src/dustrac.appdata.xml
+++ b/src/dustrac.appdata.xml
@@ -2,10 +2,10 @@
 <component type="desktop">
   <id>dustrac-game.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-3.0 and CC BY-SA-3.0</project_license>
+  <project_license>GPL-3.0 and CC-BY-SA-3.0</project_license>
   <name>Dust Racing 2D</name>
-  <summary>Traditional top-down car racing game including a level editor.</summary>
-  <summary xml:lang="de">Traditionelles Autorennspiel aus der Vogelperspektive, mit Leveleditor.</summary>
+  <summary>Traditional top-down car racing game including a level editor</summary>
+  <summary xml:lang="de">Traditionelles Autorennspiel aus der Vogelperspektive, mit Leveleditor</summary>
   <description>
     <p>
       Dust Racing 2D (Dustrac) is a tile-based, cross-platform 2D racing game written in Qt (C++) and OpenGL.


### PR DESCRIPTION
- fix one of the project license to be "CC-BY-SA-3.0": "CC BY-SA-3.0" is not a recognized license
- remove extra period at the end of summary texts