### PR TITLE
Include <stdexcept> for std::runtime_error

### DIFF
--- a/src/game/audio/openaloggdata.cpp
+++ b/src/game/audio/openaloggdata.cpp
@@ -19,6 +19,7 @@
 
 #include <cstdio>
 #include <vector>
+#include <stdexcept>
 
 #include <vorbis/vorbisfile.h>
 

--- a/src/game/audio/openalsource.cpp
+++ b/src/game/audio/openalsource.cpp
@@ -19,6 +19,7 @@
 #include <AL/alc.h>
 
 #include <memory>
+#include <stdexcept>
 
 static bool checkError()
 {

--- a/src/game/audio/openalwavdata.cpp
+++ b/src/game/audio/openalwavdata.cpp
@@ -25,6 +25,7 @@
 #include <AL/alc.h>
 #include <cassert>
 #include <cstdio>
+#include <stdexcept>
 
 static bool checkError()
 {


### PR DESCRIPTION
It was implicitly pulled before, and in GCC 10 it will not be anymore.

See also: https://gcc.gnu.org/gcc-10/porting_to.html