### PR TITLE
Roughly sort tracks by length/complexity/difficulty

### DIFF
--- a/data/levels/Crossroads.trk
+++ b/data/levels/Crossroads.trk
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<track cols="24" name="Crossroads" isUserTrack="0" rows="22" index="19" version="2.0.1">
+<track cols="24" name="Crossroads" isUserTrack="0" rows="22" index="11" version="2.0.1">
  <t i="0" j="0" o="0" t="grass"/>
  <t i="0" j="1" o="0" t="grass"/>
  <t i="0" j="2" o="0" t="grass"/>

--- a/data/levels/Diamond.trk
+++ b/data/levels/Diamond.trk
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<track rows="25" index="14" version="1.11.0" cols="20" name="Diamond">
+<track rows="25" index="4" version="1.11.0" cols="20" name="Diamond">
  <t i="0" o="0" t="sand" j="0"/>
  <t i="0" o="180" t="sandGrassStraight" j="1"/>
  <t i="0" o="0" t="grass" j="2"/>

--- a/data/levels/Far Lands.trk
+++ b/data/levels/Far Lands.trk
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<track version="1.13.0" index="15" cols="50" name="Far Lands" rows="30">
+<track version="1.13.0" index="14" cols="50" name="Far Lands" rows="30">
  <t o="0" i="0" t="grass" j="0"/>
  <t o="0" i="0" t="grass" j="1"/>
  <t o="0" i="0" t="grass" j="2"/>

--- a/data/levels/Figure 8.trk
+++ b/data/levels/Figure 8.trk
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<track version="1.13.0" index="12" cols="15" name="Figure 8" rows="15">
+<track version="1.13.0" index="2" cols="15" name="Figure 8" rows="15">
  <t o="0" i="0" t="grass" j="0"/>
  <t o="0" i="0" t="grass" j="1"/>
  <t o="0" i="0" t="grass" j="2"/>

--- a/data/levels/Radiator.trk
+++ b/data/levels/Radiator.trk
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<track version="1.13.0" index="17" cols="14" name="Radiator" rows="15">
+<track version="1.13.0" index="15" cols="14" name="Radiator" rows="15">
  <t o="0" i="0" t="sand" j="0"/>
  <t o="0" i="0" t="sand" j="1"/>
  <t o="180" i="0" t="sandGrassStraight" j="2"/>

--- a/data/levels/Twineburg.trk
+++ b/data/levels/Twineburg.trk
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<track version="1.13.0" index="18" cols="18" name="Twineburg" rows="15">
+<track version="1.13.0" index="10" cols="18" name="Twineburg" rows="15">
  <t o="0" i="0" t="grass" j="0"/>
  <t o="0" i="0" t="grass" j="1"/>
  <t o="0" i="0" t="grass" j="2"/>

--- a/data/levels/Western Valley.trk
+++ b/data/levels/Western Valley.trk
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<track cols="19" name="Western Valley" version="1.11.0" rows="23" index="16">
+<track cols="19" name="Western Valley" version="1.11.0" rows="23" index="8">
  <t i="0" o="0" t="grass" j="0"/>
  <t i="0" o="0" t="grass" j="1"/>
  <t i="0" o="0" t="grass" j="2"/>

--- a/data/levels/curvastone.trk
+++ b/data/levels/curvastone.trk
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<track index="8" version="1.13.0" rows="18" name="Curvastone" cols="30">
+<track index="12" version="1.13.0" rows="18" name="Curvastone" cols="30">
  <t o="180" j="0" t="sandGrassCorner2" i="0"/>
  <t o="90" j="1" t="sandGrassStraight" i="0"/>
  <t o="90" j="2" t="sandGrassStraight" i="0"/>

--- a/data/levels/infinity.trk
+++ b/data/levels/infinity.trk
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<track version="1.13.0" index="0" cols="22" name="Infinity" rows="8">
+<track version="1.13.0" index="1" cols="22" name="Infinity" rows="8">
  <t o="180" i="0" t="sandGrassCorner2" j="0"/>
  <t o="90" i="0" t="sandGrassStraight" j="1"/>
  <t o="90" i="0" t="sandGrassStraight" j="2"/>

--- a/data/levels/monza.trk
+++ b/data/levels/monza.trk
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<track version="1.6.3" cols="35" rows="19" index="3" name="Monza">
+<track version="1.6.3" cols="35" rows="19" index="5" name="Monza">
  <t i="0" j="0" o="180" t="sand"/>
  <t i="0" j="1" o="0" t="sand"/>
  <t i="0" j="2" o="0" t="sand"/>

--- a/data/levels/ring.trk
+++ b/data/levels/ring.trk
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<track version="1.7.3" cols="20" rows="8" index="9" name="Ring">
+<track version="1.7.3" cols="20" rows="8" index="0" name="Ring">
  <t i="0" j="0" o="0" t="grass"/>
  <t i="0" j="1" o="0" t="grass"/>
  <t i="0" j="2" o="0" t="grass"/>

--- a/data/levels/straight.trk
+++ b/data/levels/straight.trk
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<track name="Straight" rows="6" version="1.9.2" cols="40" index="7">
+<track name="Straight" rows="6" version="1.9.2" cols="40" index="9">
  <t i="0" j="0" o="0" t="sand"/>
  <t i="0" j="1" o="0" t="sand"/>
  <t i="0" j="2" o="0" t="sand"/>

--- a/data/levels/suzuka.trk
+++ b/data/levels/suzuka.trk
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<track version="1.13.0" index="11" cols="21" name="Suzuka" rows="15">
+<track version="1.13.0" index="7" cols="21" name="Suzuka" rows="15">
  <t o="0" i="0" t="grass" j="0"/>
  <t o="0" i="0" t="grass" j="1"/>
  <t o="0" i="0" t="grass" j="2"/>

--- a/data/levels/triangle.trk
+++ b/data/levels/triangle.trk
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<track name="Triangle" index="5" version="1.13.0" cols="14" rows="14">
+<track name="Triangle" index="3" version="1.13.0" cols="14" rows="14">
  <t o="180" t="sandGrassCorner2" i="0" j="0"/>
  <t o="90" t="sandGrassStraight" i="0" j="1"/>
  <t o="90" t="sandGrassStraight" i="0" j="2"/>

--- a/data/levels/twister.trk
+++ b/data/levels/twister.trk
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<track version="1.13.0" index="10" cols="10" name="Twister" rows="10">
+<track version="1.13.0" index="6" cols="10" name="Twister" rows="10">
  <t o="-180" i="0" t="sandGrassCorner2" j="0"/>
  <t o="90" i="0" t="sandGrassStraight" j="1"/>
  <t o="90" i="0" t="sandGrassStraight" j="2"/>


### PR DESCRIPTION
Fixes #75.

Sorts the tracks in the order suggested in #75.

Yes, I know you wanted to do an auto-sort sometime, but until this happens, this simple hardcoded sorting shouldn't hurt in the meantime. This is just a very lightweight and simple way to do it.

Automatic sorting can still be implemented later.