### PR TITLE
Add possibility to rely on system fonts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ option(QOpenGLFunctions "Use QOpenGLFunctions to resolve OpenGL extensions if en
 
 option(UnlockAllTracks "Unlock all tracks (for development purposes)" OFF)
 
+option(SystemFonts "Assume all the fonts are available in the system." OFF)
+
 # Default to release C++ flags if CMAKE_BUILD_TYPE not set
 if( NOT CMAKE_BUILD_TYPE )
   set( CMAKE_BUILD_TYPE Release CACHE STRING
@@ -89,6 +91,11 @@ endif()
 if (UnlockAllTracks)
     message(STATUS "All tracks unlocked")
     add_definitions(-DUNLOCK_ALL_TRACKS)
+endif()
+
+if(SystemFonts)
+    message(STATUS "Assuming system fonts")
+    add_definitions(-DSYSTEM_FONTS)
 endif()
 
 add_definitions(-DGLEW_STATIC)

--- a/INSTALL
+++ b/INSTALL
@@ -174,8 +174,10 @@ The release build should be used when packaging (give
 
 Currently the data files install to CMAKE_INSTALL_PREFIX/share/DustRacing
 and the binaries install to CMAKE_INSTALL_PREFIX/bin.
+Among the data files there are also fonts that are installed by default;
+in case they are available in the system, it is possible to not ship
+any font by giving -DSystemFonts=ON to cmake.
 
 CMAKE_INSTALL_PREFIX usually defaults to /usr/local and
 can be changed by giving, for example, -DCMAKE_INSTALL_PREFIX=/usr
 to cmake (or to the configure script).
-

--- a/InstallLinux.cmake
+++ b/InstallLinux.cmake
@@ -84,8 +84,10 @@ function(setup_install_targets BIN_PATH DATA_PATH DOC_PATH)
     install(DIRECTORY data/levels DESTINATION ${DATA_PATH} FILES_MATCHING PATTERN "*.trk")
     install(DIRECTORY data/models DESTINATION ${DATA_PATH} FILES_MATCHING PATTERN "*.obj")
     install(DIRECTORY data/sounds DESTINATION ${DATA_PATH} FILES_MATCHING PATTERN "*.ogg")
-    install(DIRECTORY data/fonts DESTINATION ${DATA_PATH} FILES_MATCHING PATTERN "*.ttf")
-    install(DIRECTORY data/fonts DESTINATION ${DATA_PATH} FILES_MATCHING PATTERN "*.txt")
+    if(NOT SystemFonts)
+        install(DIRECTORY data/fonts DESTINATION ${DATA_PATH} FILES_MATCHING PATTERN "*.ttf")
+        install(DIRECTORY data/fonts DESTINATION ${DATA_PATH} FILES_MATCHING PATTERN "*.txt")
+    endif()
     install(DIRECTORY ${CMAKE_BINARY_DIR}/data/translations DESTINATION ${DATA_PATH} FILES_MATCHING PATTERN "*.qm")
 
     # Install .desktop files

--- a/src/game/renderer.cpp
+++ b/src/game/renderer.cpp
@@ -145,6 +145,7 @@ void Renderer::loadShaders()
 
 void Renderer::loadFonts()
 {
+#ifndef SYSTEM_FONTS
     QStringList fonts = { "DejaVuSans-Bold.ttf" };
     for (auto && font : fonts)
     {
@@ -162,6 +163,7 @@ void Renderer::loadFonts()
             juzzlin::L().info() << "Loaded font " << QFontDatabase::applicationFontFamilies(appFontId).at(0).toStdString();
         }
     }
+#endif
 
     MCAssetManager::instance().textureFontManager().createFontFromData(FontFactory::generateFontData("DejaVu Sans"));
 }


### PR DESCRIPTION
Add a cmake option to disable the installation (if enabled) of the fonts, and skips their loading as files. This is useful in case the fonts are already installed in the system, so QFont loads them with no issues.