### PR TITLE
Drop the configure wrapper script

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -177,5 +177,5 @@ and the binaries install to CMAKE_INSTALL_PREFIX/bin.
 
 CMAKE_INSTALL_PREFIX usually defaults to /usr/local and
 can be changed by giving, for example, -DCMAKE_INSTALL_PREFIX=/usr
-to cmake (or to the configure script).
+to cmake.
 

--- a/configure
+++ b/configure
@@ -1,3 +1,0 @@
-#!/bin/sh
-rm -f CMakeCache.txt
-cmake . $@ && echo "Configuring compeleted. Now run \"make\"."


### PR DESCRIPTION
cmake is a widely known build system, so there is no need to add a simple wrapping script for it, even with a misleading name used by autoconf).