### PR TITLE
Fixes for MacOS

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -250,7 +250,15 @@ void Game::createRenderer()
 
     L().debug() << "Creating the renderer..";
 
-    m_renderer = new Renderer(hRes, vRes, fullScreen, m_world->renderer().glScene());
+    double pixelScale = m_screen->devicePixelRatio();
+    
+    m_renderer = new Renderer(hRes,
+                              vRes,
+                              m_screen->geometry().width(),
+                              m_screen->geometry().height(),
+                              pixelScale,
+                              fullScreen,
+                              m_world->renderer().glScene());
     m_renderer->setFormat(format);
     m_renderer->setCursor(Qt::BlankCursor);
 

--- a/src/game/renderer.cpp
+++ b/src/game/renderer.cpp
@@ -65,6 +65,7 @@ Renderer::Renderer(int hRes, int vRes, bool fullScreen, MCGLScene & glScene)
   , m_fullScreen(fullScreen)
   , m_updatePending(false)
   , m_glScene(glScene)
+  , m_rendererInitialized(false)
 {
     assert(!Renderer::m_instance);
     Renderer::m_instance = this;
@@ -101,6 +102,7 @@ void Renderer::initialize()
     loadShaders();
     loadFonts();
 
+    m_rendererInitialized = true;
     emit initialized();
 }
 
@@ -343,7 +345,8 @@ void Renderer::renderNow()
 
 void Renderer::resizeEvent(QResizeEvent * event)
 {
-    resizeGL(event->size().width(), event->size().height());
+    if (m_rendererInitialized)
+        resizeGL(event->size().width(), event->size().height());
 }
 
 void Renderer::keyPressEvent(QKeyEvent * event)

--- a/src/game/renderer.cpp
+++ b/src/game/renderer.cpp
@@ -48,7 +48,7 @@
 
 Renderer * Renderer::m_instance = nullptr;
 
-Renderer::Renderer(int hRes, int vRes, bool fullScreen, MCGLScene & glScene)
+Renderer::Renderer(int hRes, int vRes, int fullHRes, int fullVRes, int pixelScale, bool fullScreen, MCGLScene & glScene)
   : m_context(nullptr)
   , m_scene(nullptr)
   , m_eventHandler(nullptr)
@@ -57,10 +57,11 @@ Renderer::Renderer(int hRes, int vRes, bool fullScreen, MCGLScene & glScene)
   , m_zFar(10000.0f) // See: https://github.com/juzzlin/DustRacing2D/issues/30
   , m_fadeValue(1.0f)
   , m_enabled(false)
-  , m_hRes(hRes)
-  , m_vRes(vRes)
-  , m_fullHRes(Game::instance().screen()->geometry().width())
-  , m_fullVRes(Game::instance().screen()->geometry().height())
+  , m_hRes(hRes * pixelScale)
+  , m_vRes(vRes * pixelScale)
+  , m_fullHRes(fullHRes * pixelScale)
+  , m_fullVRes(fullVRes * pixelScale)
+  , m_pixelScale(pixelScale)
   , m_frameCounter(0)
   , m_fullScreen(fullScreen)
   , m_updatePending(false)
@@ -89,12 +90,16 @@ void Renderer::initialize()
     if (!m_fullScreen)
     {
         // Set window size & disable resize
-        resize(m_hRes, m_vRes);
-        setMinimumSize(QSize(m_hRes, m_vRes));
-        setMaximumSize(QSize(m_hRes, m_vRes));
+        int windowHRes = m_hRes / m_pixelScale;
+        int windowVRes = m_vRes / m_pixelScale;
+        resize(windowHRes, windowVRes);
+        setMinimumSize(QSize(windowHRes, windowVRes));
+        setMaximumSize(QSize(windowHRes, windowVRes));
 
         // Try to center the window
-        setPosition(m_fullHRes / 2 - m_hRes / 2, m_fullVRes / 2 - m_vRes / 2);
+        int screenHRes = m_fullHRes / m_pixelScale;
+        int screenVRes = m_fullVRes / m_pixelScale;
+        setPosition(screenHRes / 2 - windowHRes / 2, screenVRes / 2 - windowHRes / 2);
     }
 
     m_glScene.initialize();

--- a/src/game/renderer.hpp
+++ b/src/game/renderer.hpp
@@ -42,7 +42,7 @@ class Renderer : public QWindow, protected QOpenGLFunctions
 
 public:
     //! Constructor.
-    Renderer(int hRes, int vRes, bool fullScreen, MCGLScene & glScene);
+    Renderer(int hRes, int vRes, int fullHRes, int fullVRes, int pixelScale, bool fullScreen, MCGLScene & glScene);
 
     //! Destructor.
     virtual ~Renderer();
@@ -157,6 +157,8 @@ private:
 
     int m_fullVRes;
 
+    int m_pixelScale;
+    
     int m_frameCounter;
 
     bool m_fullScreen;

--- a/src/game/renderer.hpp
+++ b/src/game/renderer.hpp
@@ -170,6 +170,7 @@ private:
     std::unique_ptr<QOpenGLFramebufferObject> m_shadowFbo;
 
     MCGLScene & m_glScene;
+    bool m_rendererInitialized;
 };
 
 #endif // RENDERER_HPP


### PR DESCRIPTION
Hi,
I tried to build and run the game on MacBook Air M1, and I had couple of issues.
 1. Game crashes during start-up. I figured something is not initialized fully before first resizeGL is called, so I added a simple check that fixed the problem. Not sure if it's the best way though.
 2. There were an issue with screen resolution. Window was the correct size but the scene was taking only a quarter of the screen. I added pixelScale multiplier which works fine on my MacBook. Haven't tested on anything else.