### PR TITLE
Normalize steering angle

### DIFF
--- a/src/game/MiniCore/src/Core/mctrigonom.cc
+++ b/src/game/MiniCore/src/Core/mctrigonom.cc
@@ -27,6 +27,14 @@ namespace {
 const size_t LUT_SIZE = 7200;
 const float SCALE = 10;
 const float PI = 3.1415926536f;
+
+float normalize( const float value, const float start, const float end )
+{
+    const float width = end - start;
+    const float offsetValue = value - start;
+
+    return (offsetValue - (std::floor(offsetValue / width) * width)) + start;
+}
 } // namespace
 
 struct MCTrigonom::Impl
@@ -63,7 +71,9 @@ float MCTrigonom::radToDeg(float angle)
 
 float MCTrigonom::sin(float angle)
 {
-    const size_t index = static_cast<size_t>(angle * SCALE) + LUT_SIZE / 2;
+    if (angle > 360.0f || angle < -360.0f)
+        angle = normalize(angle, -360.0f, 360.0f);
+    const size_t index = static_cast<size_t>((angle * SCALE) + (LUT_SIZE / 2));
     if (index < LUT_SIZE)
     {
         return m_impl->m_sin[index];
@@ -73,7 +83,9 @@ float MCTrigonom::sin(float angle)
 
 float MCTrigonom::cos(float angle)
 {
-    const size_t index = static_cast<size_t>(angle * SCALE) + LUT_SIZE / 2;
+    if (angle > 360.0f || angle < -360.0f)
+        angle = normalize(angle, -360.0f, 360.0f);
+    const size_t index = static_cast<size_t>((angle * SCALE) + (LUT_SIZE / 2));
     if (index < LUT_SIZE)
     {
         return m_impl->m_cos[index];


### PR DESCRIPTION
This PR fixes #126
Not sure if this is the best way of fixing this, but it looks like when angle is outside -+360 degrees, index equals to 0 and by that `sin` and `cos` return wrong values.
`normalize` function stolen from [SO](https://stackoverflow.com/a/2021986/240804)