### PR TITLE
Make dataSize vars in MCMesh::initVBOs non-static

### DIFF
--- a/src/game/MiniCore/src/Graphics/mcmesh.cc
+++ b/src/game/MiniCore/src/Graphics/mcmesh.cc
@@ -104,17 +104,17 @@ void MCMesh::init(const FaceVector & faces)
 
 void MCMesh::initVBOs()
 {
-    static const auto vertexDataSize = sizeof(MCGLVertex) * vertexCount();
+    const auto vertexDataSize = sizeof(MCGLVertex) * vertexCount();
 
-    static const auto normalDataSize = sizeof(MCGLVertex) * vertexCount();
+    const auto normalDataSize = sizeof(MCGLVertex) * vertexCount();
 
-    static const auto texCoordDataSize = sizeof(MCGLTexCoord) * vertexCount();
+    const auto texCoordDataSize = sizeof(MCGLTexCoord) * vertexCount();
 
-    static const auto numColorComponents = 4;
+    const auto numColorComponents = 4;
 
-    static const auto colorDataSize = sizeof(GLfloat) * vertexCount() * numColorComponents;
+    const auto colorDataSize = sizeof(GLfloat) * vertexCount() * numColorComponents;
 
-    static const auto totalDataSize = vertexDataSize + normalDataSize + texCoordDataSize + colorDataSize;
+    const auto totalDataSize = vertexDataSize + normalDataSize + texCoordDataSize + colorDataSize;
 
     initBufferData(totalDataSize, GL_STATIC_DRAW);
 


### PR DESCRIPTION
The dataSize variables in this function are both const and static. Const makes it so that once they're first initialized, they won't be recalculated and overwritten. Static makes it so that the value is preserved between calls... except that static variables in class methods get a single instance per class, not per object.

Combined, this means that all MCMeshes use the same dataSize values, even though they may have different vertex counts. This leads to buffer overflow when calling MCGLObjectBase::addBufferSubData.